### PR TITLE
XSS sanitization + URL validation

### DIFF
--- a/refer.php
+++ b/refer.php
@@ -1,6 +1,12 @@
 <?php 
+$url_regex = "/(https?:\/\/)?([\w\-])+\.{1}([a-zA-Z]{2,63})([\/\w-]*)*\/?\??([^#\n\r]*)?#?([^\n\r]*)/i"; // copied from https://regexr.com/39p0t
+
 if(isset($_GET['url'])){
-    $url = $_GET["url"];
+    $url = htmlspecialchars($_GET["url"]); // XSS sanitization
+	if(preg_match($url_regex, $url)!==1) // prevent unwanted protocols like javascript:alert(1)
+	{
+		exit(header("Location: /index.php"));
+	}
 }
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://huntr.dev/bounties/1-other-lazycipher/url-shortener-anonymous-link-generator/

### ⚙️ Description *

The GET parameter "url" was reflected in the page without sanitization. XSS was possible

### 💻 Technical Description *

XSS due to the lack of $_GET["sanitization"].

### 🐛 Proof of Concept (PoC) *

http://127.0.0.1/refer.php?url=aaa"%3E%3Cscript%3Ealert("zer0h");%3C/script%3E
Or enter a url like `javascript:alert(1);`

### 🔥 Proof of Fix (PoF) *

http://127.0.0.1/refer.php?url=aaa"%3E%3Cscript%3Ealert("zer0h");%3C/script%3E the XSS won't work anymore
